### PR TITLE
Překlad knihy Ada a Zangemann do češtiny.

### DIFF
--- a/Ada_Zangemann-cs_jmena.txt
+++ b/Ada_Zangemann-cs_jmena.txt
@@ -11,8 +11,8 @@ cover:Obálka
 other.titlepage:Přední obálka
 chapter-01,cover:Přední obálka
 chapter-02,page_02:Tiráž
-chapter-03,page_04:Ada a Zangemann
-chapter-04,page_06:Zangemann a počítače
+chapter-03,page_04:Ada a Kleštil
+chapter-04,page_06:Kleštil a počítače
 chapter-05,page_13:Jednoho dne ...
 chapter-06,page_18:Skateboardy přestaly fungovat
 chapter-07,page_20:Ada a software
@@ -20,11 +20,11 @@ chapter-08,page_22:Programování
 chapter-09,page_25:Hrozná noc
 chapter-10,page_26:První opravdový projekt
 chapter-11,page_30:Programováním za svobodu
-chapter-12,page_36:Zangemann a prezident
+chapter-12,page_36:Kleštil a prezident
 chapter-13,page_39:Protest
 chapter-14,page_42:Děti pomáhají vládě
 chapter-15,page_44:Nový zákon
-chapter-16,page_48:A co Zangemann?
+chapter-16,page_48:A co Kleštil?
 chapter-17,page_50:Poděkování
 chapter-18,page_52:O autorovi - Matthias Kirschner
 chapter-19,page_53:O ilustrátorce - Sandra Brandstätterová
@@ -34,24 +34,24 @@ chapter-22,back_cover:Zadní obálka a synopse
 ]]
 
 [[I:cover
-OBRÁZEK: Ada a Zangemann - Příběh o softwaru, skateboardech a malinové zmrzlině
+OBRÁZEK: Ada a pan Kleštil - Příběh o softwaru, skateboardech a malinové zmrzlině
 od Matthiase Kirschnera a Sandry Brandstätterové.
-Na převážně vybledlém tmavě tyrkysovém pozadí, v rámečku tvořeném místy zakroucenými bílými linkami, které spojují myš, klávesnici a růžový smartphone, stojí proti sobě Ada a Zangemann oba s rukama v bok na znamení vzdoru. Ada se usmívá a Zangemann se mračí.
+Na převážně vybledlém tmavě tyrkysovém pozadí, v rámečku tvořeném místy zakroucenými bílými linkami, které spojují myš, klávesnici a růžový smartphone, stojí proti sobě Ada a Kleštil oba s rukama v bok na znamení vzdoru. Ada se usmívá a Kleštil se mračí.
 Ada má červené tváře a černé vlasy má na pravé a levé straně stažené červenými gumičkami do dvou velkých drdolů. V uších má malé žluté pecičkové náušnice. Je oblečena v kraťasech s vodorovnými tyrkysovými a bílými pruhy, pod žlutým tričkem jí vykukuje krajkovaný lem bílého nátělníku. Tričko i košilka jsou vytažené přes kraťasy. Přes tričko má Ada oblečenou modrou mikinu s kapucí. Na nohou má červené boty s bílými špičkami a podrážkami a nízké bílé ponožky. Jednou nohou stojí na skateboardu a druhou na zemi.
-Zangemann má krátké šedé vlasy a hranaté brýle. Na sobě má fialový rolák, světle modré kalhoty s ohrnutými nohavicemi, hnědé boty a bílé ponožky. Na ruce nosí velké moderní hodinky. Nad Zangemannem jsou kleště s červenými rukojeťmi, které přetínají rámeček z bílé linky.
+Kleštil má krátké šedé vlasy a hranaté brýle. Na sobě má fialový rolák, světle modré kalhoty s ohrnutými nohavicemi, hnědé boty a bílé ponožky. Na ruce nosí velké moderní hodinky. Nad Kleštilem jsou kleště s červenými rukojeťmi, které přetínají rámeček z bílé linky.
 ]]
 
 
 ## 1 ##
 
 [[I:ada-p01
-ADA A ZANGEMANN
+ADA A PAN KLEŠTIL
 ]]
 
 Matthias Kirschner
 Sandra Brandstätterová
 
-ADA A ZANGEMANN
+ADA A PAN KLEŠTIL
 Příběh o softwaru, skateboardech a malinové zmrzlině.
 
 ## 2 ##
@@ -60,7 +60,7 @@ Copyright © 2023 Matthias Kirschner a Sandra Brandstätterová.
 Toto dílo je chráněné licencí Creative Commons Attribution-ShareAlike 4.0 International License. Chcete-li si přečíst kopii licence, navštivte
 http://creativecommons.org/licenses/by-sa/4.0/ nebo si o ni napište na adresu Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
-<b>Ada a Zangemann: Příběh o softwaru, skateboardech a malinové zmrzlině</b> je překladem z německého originálu Ada und Zangemann: Ein Märchen über Software, Skateboards und Himbeereis, vydaného nakladatelstvím Dpunkt.verlag ve spolupráci s O’Reilly Media, Inc., pod značkou “O’REILLY,” © 2022 Matthias Kirschner and Sandra Brandstätter.
+<b>Ada a Kleštil: Příběh o softwaru, skateboardech a malinové zmrzlině</b> je překladem z německého originálu Ada und Zangemann: Ein Märchen über Software, Skateboards und Himbeereis, vydaného nakladatelstvím Dpunkt.verlag ve spolupráci s O’Reilly Media, Inc., pod značkou “O’REILLY,” © 2022 Matthias Kirschner and Sandra Brandstätter.
 
 Vydání první
 
@@ -122,16 +122,16 @@ Společnost by měla podporovat ty, kteří respektují svobodu ostatních.
 ==== Slide 1
 
 [[I:ada-p03
-OBRÁZEK: Matthias Kirschner, Sandra Brandstätterová - ADA A ZANGEMANN -
+OBRÁZEK: Matthias Kirschner, Sandra Brandstätterová - ADA A PAN KLEŠTIL -
 Příběh softwaru, skateboardů a malinové zmrzliny.
-Titulek uprostřed, autoři nahoře vlevo. Dole vpravo je Adin pes. Má
+Titulek uprostřed, autoři nahoře vlevo. Dole vpravo Adin pes. Má
 šedivou srst s bílými skvrnami, červený obojek se svítícími
 žlutými LED a vrtí ocasem.
 ]]
 Matthias Kirschner
 Sandra Brandstätterová
 
-ADA a ZANGEMANN
+ADA a PAN KLEŠTIL
 
 Příběh o softwaru, skateboardech a malinové zmrzlině.
 
@@ -164,16 +164,16 @@ Pod verandou je matrace, červený sud od oleje a šedý kufr. Za domem jsou hro
 ## 5 ##
 
 [[I:ada-p05
-IMAGE: Hromádka prestižních časopisů (“Stars“, “Money”, “Největší boháč”) a na titulních stranách je Zangemann a jeho vila.
+IMAGE: Hromádka prestižních časopisů (“Stars“, “Money”, “Největší boháč”) a na titulních stranách je Kleštil a jeho vila.
 ]]
 
-Daleko odtud, na opačném konci města, žil slavný vynálezce Zangemann. Byl nesmírně bohatý. Jeho konto přetékalo číslicemi a nulami. Zangemann bydlel v obrovském domě s bazénem a tobogánem, se spoustou schodů a věží, se stovkami oken a tolika pokoji, že se v nich často ztrácel i on sám. Zangemannovo sídlo se nacházelo vysoko na kopci a celé město měl pod sebou jako na dlani.
+Daleko odtud, na opačném konci města, žil slavný vynálezce Kleštil. Byl nesmírně bohatý. Jeho konto přetékalo číslicemi a nulami. Kleštil bydlel v obrovském domě s bazénem a tobogánem, se spoustou schodů a věží, se stovkami oken a tolika pokoji, že se v nich často ztrácel i on sám. Kleštilovo sídlo se nacházelo vysoko na kopci a celé město měl pod sebou jako na dlani.
 
 ## 6 ##
 
 ==== Slide 3
 
-Počítače fascinovaly Zangemanna už od dětství. Když byl malý, byly to obrovské stroje, ve kterých se proplétaly dráty a hučely ventilátory. Ve škole pak malý Zangemann často snil o tom, co všechno by s počítači dokázal, kdyby byly jen o něco menší – dost malé na to, aby se vešly do nejrůznějších věcí.
+Počítače fascinovaly Kleštila už od dětství. Když byl malý, byly to obrovské stroje, ve kterých se proplétaly dráty a hučely ventilátory. Ve škole pak malý Kleštil často snil o tom, co všechno by s počítači dokázal, kdyby byly jen o něco menší – dost malé na to, aby se vešly do nejrůznějších věcí.
 Jako první by zabudoval počítač do svého skateboardu, který by při jízdě vydával parádní zvuky – třeba jako hasičská siréna nebo startující raketa.
 A vymyslel by i stroj na zmrzlinu! Počítač by uměl namíchat ty nejlepší příchutě a rovnou by je i prodával. Jeho automaty by stály na každém rohu, takže by si mohl kdykoli skočit pro svou oblíbenou zmrzlinu.
 Také by postavil robota na úklid a stroj na třídění stavebnic, aby měl ve svém pokoji vždy krásně uklizeno. Každý den měl nový nápad a nemyslel téměř na nic jiného.
@@ -183,24 +183,24 @@ A skutečně – čím byl starší, tím byly počítače menší. Když dokon�
 ## 7 ##
 
 [[I:ada-p07
-OBRÁZEK: Zangemann sedící ve školní lavici. Jeho myšlenky jsou znázorněny jako šest bublin s nápady, kam by šlo vložit počítače: systém pro videohovory, reproduktor, pračka, skateboard s rádiovým ovládáním, náramkový počítač a přenosný počítač i s monitorem a klávesnicí. Zangemann má šedé vlasy, nosí brýle a má tmavě fialové tričko s modrými vodorovnými pruhy, modré šortky, hnědé boty a bílé ponožky. Na levém zápěstí má velké moderní hodinky. Na stole je otevřený sešit, žlutá tužka a guma. Na boku lavice visí jeho hnědá aktovka.
+OBRÁZEK: Kleštil sedící ve školní lavici. Jeho myšlenky jsou znázorněny jako šest bublin s nápady, kam by šlo vložit počítače: systém pro videohovory, reproduktor, pračka, skateboard s rádiovým ovládáním, náramkový počítač a přenosný počítač i s monitorem a klávesnicí. Kleštil má šedé vlasy, nosí brýle a má tmavě fialové tričko s modrými vodorovnými pruhy, modré šortky, hnědé boty a bílé ponožky. Na levém zápěstí má velké moderní hodinky. Na stole je otevřený sešit, žlutá tužka a guma. Na boku lavice visí jeho hnědá aktovka.
 ]]
 
 ## 8 ##
 
 ==== Slide 4
 
-„Konečně můžu všechny své nápady uskutečnit!“ jásal Zangemann a pustil se do práce. Zabudoval malé počítače do nejrůznějších zařízení a vylepšil tak jejich praktičtnost. A tyto přístroje pak prodával.
+„Konečně můžu všechny své nápady uskutečnit!“ jásal Kleštil a pustil se do práce. Zabudoval malé počítače do nejrůznějších zařízení a vylepšil tak jejich praktičtnost. A tyto přístroje pak prodával.
 
 [[I:ada-p08b
-OBRÁZEK: Zangemannova originální zmrzlinovačka.
+OBRÁZEK: Kleštilova originální zmrzlinovačka.
 Je světle modrá, podobná automatu na nápoje, ale místo kelímku je zde kornoutek, který se plní zmrzlinou. Nad dávkovačem je monitor, který ukazuje příchuť zmrzliny, která se právě podává. V tomto případě je to ananasová zmrzlina.
 Vlevo se nachází otvor pro vkládání mincí, různé tlačítka pro výběr příchutě a otvor pro vracení mincí. Nahoře je kulatý bílý znak s kopečkem cukrově růžové zmrzliny v kornoutku.
-Na zadní straně stroje, na chladícím zařízení, je logo ve tvaru písmene „Z“ jako "Zangemann".
+Na zadní straně stroje, na chladícím zařízení, je logo ve tvaru písmene „K“ jako "Kleštil".
 ]]
-Dospělí i děti jeho vynálezy milovali. Děti chtěly mít Zangemannův skateboard a k němu pokaždé ten nejnovější zvuk, aby se s ním mohly jaksepatří chlubit kamarádům na školním dvoře. Mnozí měli také jeho praktické reproduktory. Jakmile se do nich řekl název písně, ta se hned začala přehrávat. Komu ještě nějaké kapesné zbylo, mohl si odpoledne koupit automaticky namíchanou zmrzlinu z originální Zangemannovy zmrzlinovačky. Vypadalo to jako kouzla, ale vše zařizovaly malé počítače, které Zangemann do svých přístrojů vestavěl.
+Dospělí i děti jeho vynálezy milovali. Děti chtěly mít Kleštilův skateboard a k němu pokaždé ten nejnovější zvuk, aby se s ním mohly jaksepatří chlubit kamarádům na školním dvoře. Mnozí měli také jeho praktické reproduktory. Jakmile se do nich řekl název písně, ta se hned začala přehrávat. Komu ještě nějaké kapesné zbylo, mohl si odpoledne koupit automaticky namíchanou zmrzlinu z originální Kleštilovy zmrzlinovačky. Vypadalo to jako kouzla, ale vše zařizovaly malé počítače, které Kleštil do svých přístrojů vestavěl.
 [[I:ada-p08a
-OBRÁZEK: Originální Zangemannův elektrický skateboard zanechávající modrou stopu s notami a barevnými kruhy. Z dítěte, které jede na skateboardu, jsou vidět jenom kolena, bílé ponožky a olivově zelené tenisky s bílou podrážkou.
+OBRÁZEK: Originální Kleštilův elektrický skateboard zanechávající modrou stopu s notami a barevnými kruhy. Z dítěte, které jede na skateboardu, jsou vidět jenom kolena, bílé ponožky a olivově zelené tenisky s bílou podrážkou.
 ]]
 
 ## 9 ##
@@ -223,9 +223,9 @@ Tolik ji bavilo stavět a opravovat věci na vrakovišti, že nakonec na skatebo
 
 ==== Slide 6
 
-Protože lidé Zangemannovy vynálezy nadšeně kupovali, stal se brzy nejbohatším člověkem na světě. Za své nesmírné bohatství si pořídil zlatý počítač s klávesnicí osázenou drahokamy a umístil ho do největšího sálu své vily. Odtud pak přes internet řídil všechny ty malé počítače, které zabudoval do svých vynálezů.
+Protože lidé Kleštilovy vynálezy nadšeně kupovali, stal se brzy nejbohatším člověkem na světě. Za své nesmírné bohatství si pořídil zlatý počítač s klávesnicí osázenou drahokamy a umístil ho do největšího sálu své vily. Odtud pak přes internet řídil všechny ty malé počítače, které zabudoval do svých vynálezů.
 
-Stačilo zmáčknout správnou klávesu a všechny zmrzlinové stroje ve městě začaly vydávat vanilkovou zmrzlinu. Když měl chuť na čokoládovou, jednoduše zadal jinou kombinaci. A když spustil příkaz pro citronovou, vyráběly stroje už jen citrónovou. Zangemann své vynálezy zbožňoval a obdivoval, jak spolehlivě plní každé jeho přání. Lidé sice bývali zklamaní, když jejich oblíbená příchuť zrovna nebyla k mání, ale co naplat – zmrzlina byla alespoň na každém rohu.
+Stačilo zmáčknout správnou klávesu a všechny zmrzlinové stroje ve městě začaly vydávat vanilkovou zmrzlinu. Když měl chuť na čokoládovou, jednoduše zadal jinou kombinaci. A když spustil příkaz pro citronovou, vyráběly stroje už jen citrónovou. Kleštil své vynálezy zbožňoval a obdivoval, jak spolehlivě plní každé jeho přání. Lidé sice bývali zklamaní, když jejich oblíbená příchuť zrovna nebyla k mání, ale co naplat – zmrzlina byla alespoň na každém rohu.
 
 [[I:ada-p10
 OBRÁZEK: Bílá prodlužovací šňůra připojená do nástěnné zásuvky. Prodlužovací šňůra má lištu se třemi zásuvkami a na ní zelený vypínač. V jedné ze zásuvek je zastrčená šedá elektrická šňůra.
@@ -236,32 +236,32 @@ OBRÁZEK: Bílá prodlužovací šňůra připojená do nástěnné zásuvky. Pr
 Bavilo ho mačkat třpytivé klávesy a dívat se, jak lidé s chutí mlsají. Hodiny denně trávil u svého počítače a dlouhým dalekohledem pozoroval město pod sebou – jak přesně jeho stroje plní své úkoly.
 
 [[I:ada-p11
-OBRÁZEK: Zangemann sedí před zlatým počítačem ve zlatém křesle s velmi vysokým červeným polstrovaným opěradlem, na jehož vrcholu je „Z“, logo Zangemanna. Má na sobě fialový rolák a světle modré kalhoty. Počítač má čtyři zdobené monitory různých velikostí, na jejichž zadní straně je logo. Počítač je zabudován do drahého dřevěného stolu, ze kterého vychází šedý kabel, jenž je připojen k prodlužovací šňůře z předchozí stránky.
+OBRÁZEK: Kleštil sedí před zlatým počítačem ve zlatém křesle s velmi vysokým červeným polstrovaným opěradlem, na jehož vrcholu je „K“, logo Kleštila. Má na sobě fialový rolák a světle modré kalhoty. Počítač má čtyři zdobené monitory různých velikostí, na jejichž zadní straně je logo. Počítač je zabudován do drahého dřevěného stolu, ze kterého vychází šedý kabel, jenž je připojen k prodlužovací šňůře z předchozí stránky.
 ]]
 
 ## 12 ##
 
 ==== Slide 7
 
-Když zrovna neseděl u svého zlatého počítače, vymýšlel Zangemann další a další přístroje s mikropočítači a posílal je na trh.
+Když zrovna neseděl u svého zlatého počítače, vymýšlel Kleštil další a další přístroje s mikropočítači a posílal je na trh.
 Postavil pračky, které uměly poslat zprávu na mobil, jakmile se prádlo vypralo. Vysavače, které místo hlučného funění hrály veselou hudbu. Lampy, které se rozsvítily lusknutím prstů. A dokonce auta, která uměla navigovat do nejbližšího supermarketu.
 
 [[I:ada-p12
 OBRÁZEK: Pohled na město s domy a obchody, uprostřed je ulice směřující doprava. Po silnici jede malé červené auto a v protějšímu pruhu cyklista v modrém dresu.
-Po ulici chodí děti i dospělí,  jezdí na skateboardech, někteří jedí zmrzlinu, zatímco jiní si ji teprve kupují z originálních Zangemannových strojů.
+Po ulici chodí děti i dospělí,  jezdí na skateboardech, někteří jedí zmrzlinu, zatímco jiní si ji teprve kupují z originálních Kleštilových strojů.
 ]]
 
-Brzy byl Zangemannův počítač zabudovaný skoro v každém zařízení. Ne všechno, co vymyslel, bylo nakonec tak praktické, jak se zdálo. Ale to nevadilo – lidé od něj kupovali úplně všechno.
-Takový byl zkrátka svět. Každý chtěl mít zařízení od Zangemanna, největšího vynálezce na světě.
+Brzy byl Kleštilův počítač zabudovaný skoro v každém zařízení. Ne všechno, co vymyslel, bylo nakonec tak praktické, jak se zdálo. Ale to nevadilo – lidé od něj kupovali úplně všechno.
+Takový byl zkrátka svět. Každý chtěl mít zařízení od Kleštila, největšího vynálezce na světě.
 
 ## 13 ##
 
-Jednoho dne si Zangemann řekl: „Dneska si své vynálezy prohlédnu zblízka!“
+Jednoho dne si Kleštil řekl: „Dneska si své vynálezy prohlédnu zblízka!“
 Odložil dalekohled a plný očekávání se vydal po schodech dolů do města, aby si osobně užil, jak skvěle jeho přístroje fungují.
 
 [[I:ada-p13
-OBRÁZEK: Zangemann schází po schodech ze svého sídla na kopci směrem k městu.
-Zangemannův dům stojí na kopci. Přední část je modrá s velkými okny; věže jsou tmavě modré a z jednoho okna vede žlutý tobogán, který ústí ve velkém bazénu se dvěma palmami. Střechy jsou červené a na nejvyšší věží je instalována anténa. Po stranách schodů vedoucích z kopce dolů rostou stromy.
+OBRÁZEK: Kleštil schází po schodech ze svého sídla na kopci směrem k městu.
+Kleštilův dům stojí na kopci. Přední část je modrá s velkými okny; věže jsou tmavě modré a z jednoho okna vede žlutý tobogán, který ústí ve velkém bazénu se dvěma palmami. Střechy jsou červené a na nejvyšší věží je instalována anténa. Po stranách schodů vedoucích z kopce dolů rostou stromy.
 ]]
 
 ## 14 ##
@@ -273,39 +273,39 @@ Zangemannův dům stojí na kopci. Přední část je modrá s velkými okny; v�
 Byl úplně zabraný do svých myšlenek, když najednou – BUM! Něco mu prudce narazilo do holeně.
 
 [[I:ada-p14
-OBRÁZEK: Zangemann po incidentu s dítětem. Zangemann křičí bolestí a oběma rukama se drží za holeň. Dítě má hnědé vlasy, které vlají v proudu Zangemannova křiku. Na sobě má světle modrou mikinu s kapucí a tmavě zelené kalhoty. V ruce drží Zangemannův elektrický skateboard červené barvy.
+OBRÁZEK: Kleštil po incidentu s dítětem. Kleštil křičí bolestí a oběma rukama se drží za holeň. Dítě má hnědé vlasy, které vlají v proudu Kleštilova křiku. Na sobě má světle modrou mikinu s kapucí a tmavě zelené kalhoty. V ruce drží Kleštilův elektrický skateboard červené barvy.
 ]]
 
 ## 15 ##
 
-Zaskučel bolestí a rozhlédl se. Před ním stál malý kluk s vyděšeným výrazem a pod paží svíral Zangemannův elektrický skateboard.
-„Promiňte, to jsem nechtěl,“ koktal, ale Zangemann ho už neposlouchal.
+Zaskučel bolestí a rozhlédl se. Před ním stál malý kluk s vyděšeným výrazem a pod paží svíral Kleštilův elektrický skateboard.
+„Promiňte, to jsem nechtěl,“ koktal, ale Kleštil ho už neposlouchal.
 
 Se zamračenou tváří se belhal pryč. Vtom se zničehonic ozvala hlasitá hudba. Tak hrozný rámus ještě nikdy neslyšel! Rozhlédl se – a uviděl dítě na druhé straně ulice, jak drží reproduktor jeho vlastní výroby.
-Dítě vypadalo spokojeně, ale Zangemannovi se z toho spustila strašná bolest hlavy a jeho vztek jen rostl.
+Dítě vypadalo spokojeně, ale Kleštilovi se z toho spustila strašná bolest hlavy a jeho vztek jen rostl.
 Tak takhle si svou procházku rozhodně nepředstavoval!
 
 [[I:ada-p15
-OBRÁZEK: Reklamní plocha s reklamou na Zangemannův elektrický skateboard a Zangemannovu pračku. Nalevo stojí reklamní stojánek s reklamou na Zangemannovu zmrzlinu. Učitelka matematiky, paní Gernetová, prochází kolem billboardů. Paní Gernetová je starší dáma s krátkými bílými kudrnatými vlasy. Má na sobě světle zelenou košili,  khaki zelený svetr, tmavě hnědé 3/4 kalhoty a světle zelené boty na podpatku. Přes rameno nese fuchsiovou kabelku. Tlačí malý nákupní vozík, ve kterém sedí malý jezevčík s obojkem a známkou.
+OBRÁZEK: Reklamní plocha s reklamou na Kleštilův elektrický skateboard a Kleštilovu pračku. Nalevo stojí reklamní stojánek s reklamou na Kleštilovu zmrzlinu. Učitelka matematiky, paní Zlomková, prochází kolem billboardů. Paní Zlomková je starší dáma s krátkými bílými kudrnatými vlasy. Má na sobě světle zelenou košili,  khaki zelený svetr, tmavě hnědé 3/4 kalhoty a světle zelené boty na podpatku. Přes rameno nese fuchsiovou kabelku. Tlačí malý nákupní vozík, ve kterém sedí malý jezevčík s obojkem a známkou.
 ]]
 
 ## 16 ##
 
 ==== Slide 9
 
-Zangemann se na děti strašlivě rozhněval. Jak mohly takhle zneužít jeho vynálezy!
+Kleštil se na děti strašlivě rozhněval. Jak mohly takhle zneužít jeho vynálezy!
 Nemohl usnout, a tak si uprostřed noci sedl ke svému zlatému počítači.
 Všem malým počítačům ve skateboardech zadal příkaz, aby na chodnících přestaly fungovat.
 Reproduktorům přikázal, že nesmějí hrát nahlas, pokud nehrají jeho oblíbené melodie. A aby si spravil náladu, hned si nechal pár svých oblíbených kousků zahrát.
 
 [[I:ada-p16
-OBRÁZEK: Město ve večerních hodinách, s domy, kostelem a dvěma pouličními lampami. Z oken domů vycházejí komixové bubliny znázorňující Zangemannovy vynálezy, které si obyvatelé koupili: pračka, žlutý vysavač a červené auto. Všechny vynálezy jsou on-line, což ukazují plné čárky síťového připojení.
+OBRÁZEK: Město ve večerních hodinách, s domy, kostelem a dvěma pouličními lampami. Z oken domů vycházejí komixové bubliny znázorňující Kleštilovy vynálezy, které si obyvatelé koupili: pračka, žlutý vysavač a červené auto. Všechny vynálezy jsou on-line, což ukazují plné čárky síťového připojení.
 ]]
 
 ## 17 ##
 
 [[I:ada-p17
-OBRÁZEK: Pokračování předchozího obrázku, kde je v pozadí kopec s Zangemannovým domem, ze kterého anténa vysílá signály pro ovládání různých zařízení. V dalších bublinách jsou: červený elektrický skateboard, žárovka, zmrzlinový stroj a toaleta. Všechny přijímají příkazy od Zangemanna.
+OBRÁZEK: Pokračování předchozího obrázku, kde je v pozadí kopec s Kleštilovým domem, ze kterého anténa vysílá signály pro ovládání různých zařízení. V dalších bublinách jsou: červený elektrický skateboard, žárovka, zmrzlinový stroj a toaleta. Všechny přijímají příkazy od Kleštila.
 ]]
 
 ## 18 ##
@@ -391,14 +391,14 @@ Bude to pořádný projekt, možná na celé letní prázdniny… Nemohla se do�
 ## 24 ##
 
 [[I:ada-p24
-OBRÁZEK: Zangemann má ruce zkřížené na prsou a zamyšleně hledí ven z okna svého domu, na který dopadají sluneční paprsky.
+OBRÁZEK: Kleštil má ruce zkřížené na prsou a zamyšleně hledí ven z okna svého domu, na který dopadají sluneční paprsky.
 ]]
 
 ## 25 ##
 
 ==== Slide 13
 
-Od té hrozné procházky Zangemann každou noc špatně spal. Když večer ulehl do postele, hlavou mu vířily obrovské starosti: „Ach ne, mé úžasné vynálezy! Nemůžu přece dovolit, aby si s nimi všichni jen tak hráli. Co všechno by se mohlo stát! A přitom jsem to všechno tak pečlivě naplánoval.“ Převaloval se celou noc a přemýšlel, jak to zastavit.
+Od té hrozné procházky Kleštil každou noc špatně spal. Když večer ulehl do postele, hlavou mu vířily obrovské starosti: „Ach ne, mé úžasné vynálezy! Nemůžu přece dovolit, aby si s nimi všichni jen tak hráli. Co všechno by se mohlo stát! A přitom jsem to všechno tak pečlivě naplánoval.“ Převaloval se celou noc a přemýšlel, jak to zastavit.
 
 Ráno vstal s bolavou hlavou a učinil rozhodnutí. Takhle to dál nejde! Sedl ke svému zlatému počítači a začal psát – jeden program za druhým. Každému zařízení určil, co smí a co nesmí dělat. Konec chaosu!
 
@@ -407,7 +407,6 @@ Když měl hotovo, poslal všechny nové příkazy do svých vynálezů. Reprodu
 ## 26 ##
 
 ==== Slide 14
-
 Letní prázdniny byly už v půlce. Ada stála před svým velkým projektem a drbala se zamyšleně na hlavě. Ze starých součástek postavila skateboard a připojila k němu motor, který roztáčel kola. Díky tomu by mohla jezdit do knihovny nebo na vrakoviště mnohem rychleji. Byl to skvělý nápad – jenže nefungoval. Jakmile si stoupla na prkno a zmáčkla tlačítko „Start“, kola se roztočila příliš rychle. Ada z prkna pokaždé spadla. Zkoušela všechno možné, ale udržet se na něm prostě nešlo.
 
 Když spadla na zadek asi po sto padesáté, rozhodla se zajít do knihovny – tam přece vždycky našla odpovědi. A opravdu. Na internetu narazila na program, který někdo napsal pro svou elektrickou koloběžku. Ta se rozjížděla pomalu – přesně jak Ada potřebovala. Ada si program stáhla do mobilu. 
@@ -417,15 +416,15 @@ Jakmile se vrátila na vrakoviště, upravila několik řádků kódu a přepsal
 ## 27 ##
 
 [[I:ada-p27
-OBRÁZEK: Ada uhání na svém elektrickém skateboardu po chodníku. Adin skateboard je modrý, s šedými a růžovými kolečky; elektronická část je umístěna nad skateboardem (na rozdíl od Zangemannových skateboardů, kde je elektronika umístěna pod). Ada drží v obou rukou dálkové ovládání s krátkou anténou, aby ho mohla řídit. Za Adou jdou Marie a Toni, kteří nesou své skateboardy v podpaží a s úžasem sledují, jak Ada sviští před nimi.
+OBRÁZEK: Ada uhání na svém elektrickém skateboardu po chodníku. Adin skateboard je modrý, s šedými a růžovými kolečky; elektronická část je umístěna nad skateboardem (na rozdíl od Kleštilových skateboardů, kde je elektronika umístěna pod). Ada drží v obou rukou dálkové ovládání s krátkou anténou, aby ho mohla řídit. Za Adou jdou Marie a Tonda, kteří nesou své skateboardy v podpaží a s úžasem sledují, jak Ada sviští před nimi.
 
 Marie má dlouhé tmavé vlasy spletené do dvou copů sepnutých oranžovými sponkami, žluté náušnice, fuchsiové tričko s bílými rukávy s fialovými vodorovnými pruhy, bílou sukni, bílé a žluté tenisky, bílé ponožky, bílý klobouk se žlutými stranami a světle fialový batoh. Místo pravé nohy má Marie modrou protézu. Její skateboard je modrý se žlutými kolečky.
 
-Toni má zrzavé vlasy krátce ostříhané po stranách. Má na sobě modrou mikinu, tmavě zelené kalhoty a bílé boty. Má červený batoh s bílými prvky a popruhy. Jednu ruku má u úst, jakoby přemýšlel. Jeho skateboard je fialový s oranžovými kolečky.
+Tonda má zrzavé vlasy krátce ostříhané po stranách. Má na sobě modrou mikinu, tmavě zelené kalhoty a bílé boty. Má červený batoh s bílými prvky a popruhy. Jednu ruku má u úst, jakoby přemýšlel. Jeho skateboard je fialový s oranžovými kolečky.
 
 Opačným směrem jde po chodníku otec se synem: otec má na sobě modré kostkované sako a modré kalhoty a drží hnědou aktovku. Usmívá se na Adu.
 
-Jeho syn má modrou košili, modré kraťasy, bílé boty, hnědý batoh a červeno-bílou čepici. V podpaží drží žlutý Zangemannův skateboard se světle hnědými kolečky a směje se na Adu.
+Jeho syn má modrou košili, modré kraťasy, bílé boty, hnědý batoh a červeno-bílou čepici. V podpaží drží žlutý Kleštilův skateboard se světle hnědými kolečky a směje se na Adu.
 V pozadí je pekárna s velkými okny, skrz které je vidět chléb. Na straně za rohem má zeleno-bílou pruhovanou markýzu a také reklamní ceduli s menu. Na zdi visí vývěsní štít ve tvaru preclíku. Na silnici je louže, která odráží modrou oblohu.
 ]]
 
@@ -436,21 +435,21 @@ V pozadí je pekárna s velkými okny, skrz které je vidět chléb. Na straně 
 Když se Ada po prázdninách objevila ve škole na svém elektrickém skateboardu, ostatní děti jen zíraly. O velké přestávce ji obklopili zvědaví spolužáci. „Jak to, že můžeš jezdit po chodníku?“ ptali se překvapeně.
 
 [[I:ada-p28
-OBRÁZEK: Ada stojí na svém skateboardu obklopena dětmi. Na jednom konci je Marie, která ukazuje na Adin skateboard a něco říká. Vedle ní stojí Konrad s krátkými blond vlasy, tmavě šedou helmou, brýlemi, zeleným tričkem s bílým límečkem a manžetami, světle modrými kalhotami s bílými manžetami a šedými botami s bílými podrážkami. Má červený skateboard s oranžovými kolečky. Za Adou stojí další čtyři děti. Na druhém konci stojí Toni a usmívá se. Jednou rukou si sahá na bradu, zatímco v druhé ruce za šňůrky drží žlutou helmu.
+OBRÁZEK: Ada stojí na svém skateboardu obklopena dětmi. Na jednom konci je Marie, která ukazuje na Adin skateboard a něco říká. Vedle ní stojí Karlík s krátkými blond vlasy, tmavě šedou helmou, brýlemi, zeleným tričkem s bílým límečkem a manžetami, světle modrými kalhotami s bílými manžetami a šedými botami s bílými podrážkami. Má červený skateboard s oranžovými kolečky. Za Adou stojí další čtyři děti. Na druhém konci stojí Tonda a usmívá se. Jednou rukou si sahá na bradu, zatímco v druhé ruce za šňůrky drží žlutou helmu.
 ]]
 
 ## 29 ##
 
 Ada se zamyslela. „Myslím, že to není samotným skateboardem, ale tím, co je naprogramované vevnitř – softwarem. Pravděpodobně je tam nastaveno, že nesmí jezdit po chodníku. Ale to se dá změnit!“
 
-Večer si Ada vzala do parády skateboard svého spolužáka Toniho. Pracovala tajně dlouho do noci – a ráno už Toni znovu svištěl po chodníku. Jenže skateboard přestal vydávat zvuky, které do něj rodiče koupili. Místo nich se každých deset minut ozval zvláštní zvuk, jako kdyby si někdo pořádně říhnul. Ada věděla, že do programu se občas chybička vloudí.
+Večer si Ada vzala do parády skateboard svého spolužáka Tondu. Pracovala tajně dlouho do noci – a ráno už Tonda znovu svištěl po chodníku. Jenže skateboard přestal vydávat zvuky, které do něj rodiče koupili. Místo nich se každých deset minut ozval zvláštní zvuk, jako kdyby si někdo pořádně říhnul. Ada věděla, že do programu se občas chybička vloudí.
 
-A Toniho říhající skateboard nakonec všechny dost pobavil.
+A Tondův říhající skateboard nakonec všechny dost pobavil.
 
 [[I:ada-p29
 OBRÁZEK: Skákací panák nakreslený křídou na asfaltu. V řadě, uvnitř čtverců, jsou čísla 1, 2; 3 a 4 vedle sebe; 5, 6; a 7 a 8 vedle sebe. Číslo 9 není uvnitř čtverce, ale uvnitř širšího půlkruhu za čtverci s čísly 7 a 8.
 Mezi číslem 1 a číslem 2 je modrá láhev s bílými puntíky.
-Žlutý Zangemannův skateboard s oranžovými kolečky stojí tak, že zakrývá číslo 1.
+Žlutý Kleštilův skateboard s oranžovými kolečky stojí tak, že zakrývá číslo 1.
 ]]
 
 ## 30 ##
@@ -461,7 +460,7 @@ Každé odpoledne teď chodilo za Adou na vrakoviště víc a víc dětí. Ada j
 
 ==== Slide 17
 
-A to nebylo všechno! Díky softwaru mohly teď děti svým skateboardům přidávat nové a zábavné funkce. Marie připevnila na prkno barevná LED světýlka, která měnila barvu podle rychlosti jízdy. A Konrad si nainstaloval staré vrtule, díky kterým byl ještě rychlejší. 
+A to nebylo všechno! Díky softwaru mohly teď děti svým skateboardům přidávat nové a zábavné funkce. Marie připevnila na prkno barevná LED světýlka, která měnila barvu podle rychlosti jízdy. A Karlík si nainstaloval staré vrtule, díky kterým byl ještě rychlejší. 
 
 [[I:ada-p30
 OBRÁZEK: Zelená baterie s červenými a žlutými dráty, prodlužovačka, lepidlo, rolička pájky a dvě tužky.
@@ -469,7 +468,7 @@ OBRÁZEK: Zelená baterie s červenými a žlutými dráty, prodlužovačka, lep
 
 ## 31 ##
 
-Ada, Toni, Marie a Konrad teď trávili spoustu času na vrakovišti. Dokonce si tam zařídili vlastní dílnu, kde celé hodiny vylepšovali své programy. A při tom poslouchali hudbu z reproduktorů, které Ada kdysi postavila pro Alana. „Reproduktory tvého bráchy jsou mnohem hlasitější než ty naše,“ poznamenal Toni, zatímco si na helmu připevňoval rychloměr. „To bude určitě tím softwarem,“ řekla Marie.
+Ada, Tonda, Marie a Karlík teď trávili spoustu času na vrakovišti. Dokonce si tam zařídili vlastní dílnu, kde celé hodiny vylepšovali své programy. A při tom poslouchali hudbu z reproduktorů, které Ada kdysi postavila pro Alana. „Reproduktory tvého bráchy jsou mnohem hlasitější než ty naše,“ poznamenal Tonda, zatímco si na helmu připevňoval rychloměr. „To bude určitě tím softwarem,“ řekla Marie.
 
 A tak změnili program i v reproduktorech. Pak hudbu zesílili, jak jen to šlo – a začala divoká taneční párty!
 
@@ -480,16 +479,16 @@ OBRÁZEK: Šroubovák s oranžovo-šedou rukojetí, červené kleště a tři LE
 ## 32 ##
 
 [[I:ada-p32
-OBRÁZEK: Dílna na vrakovišti pod verandou Adina domu. Ada sedí na bedně od minerálek, jednu nohou ohnutou pod sebou, a používá páječku. Vedle ní stojí Konrad a rozebírá reproduktor.
+OBRÁZEK: Dílna na vrakovišti pod verandou Adina domu. Ada sedí na bedně od minerálek, jednu nohou ohnutou pod sebou, a používá páječku. Vedle ní stojí Karlík a rozebírá reproduktor.
 Marie sedí na dvou pneumatikách, opírá si ruku o stůl a o svůj převrácený skateboard, ze kterého trčí dráty. Mluví s Alanem, který stojí s rukama opřenýma o stejný stůl.
-Na stole jsou také kleště, dva klíče, cívka s pájkou, plechovka modré barvy (trochou barvy je pokapán i stůl), džbán a dvě sklenice s růžovým nápojem. Toni testuje svůj skateboard s přidanými žlutými křídly a ventilátorem. Skateboard krkne.
+Na stole jsou také kleště, dva klíče, cívka s pájkou, plechovka modré barvy (trochou barvy je pokapán i stůl), džbán a dvě sklenice s růžovým nápojem. Tonda testuje svůj skateboard s přidanými žlutými křídly a ventilátorem. Skateboard krkne.
 ]]
 
 ## 33 ##
 
 [[I:ada-p33
-OBRÁZEK: Marie a Adina máma tančí tváří v tvář. Alan, Ada a Konrad tančí v kruhu.
-Vpravo hraje reproduktor,  který postavený na sudu od oleje. Vedle reproduktoru tančí na prkně dvě myši. Toni skáče přes pneumatiky. Adin pes vyje a z jeho tlamy vycházejí dvě pokroucené osminové noty.
+OBRÁZEK: Marie a Adina máma tančí tváří v tvář. Alan, Ada a Karlík tančí v kruhu.
+Vpravo hraje reproduktor,  který postavený na sudu od oleje. Vedle reproduktoru tančí na prkně dvě myši. Tonda skáče přes pneumatiky. Adin pes vyje a z jeho tlamy vycházejí dvě pokroucené osminové noty.
 ]]
 
 ## 34 ##
@@ -503,24 +502,24 @@ růžová zmrzlina ve tvaru ryby, zmrzlina ve tvaru pyramidy s bonbóny, čokol�
 ## 35 ##
 ==== Slide 18
 
-Každé odpoledne si Ada a její kamarádi vymýšleli, co nového podniknou. Z jedné staré zmrzlinovačky postavili úplně nový stroj, který vyráběl zmrzlinu ve všech možných barvách a tvarech – hranatou, srdíčkovou, dokonce i pyramidovou! Byla malinová, jahodová, duhová, s posypem a čokoládou… A chutnala stokrát líp než ta ze Zangemannových automatů.
+Každé odpoledne si Ada a její kamarádi vymýšleli, co nového podniknou. Z jedné staré zmrzlinovačky postavili úplně nový stroj, který vyráběl zmrzlinu ve všech možných barvách a tvarech – hranatou, srdíčkovou, dokonce i pyramidovou! Byla malinová, jahodová, duhová, s posypem a čokoládou… A chutnala stokrát líp než ta ze Kleštilových automatů.
 
-Někdy dokázali pomoct i dospělým. Toni přeprogramoval tatínkův žehlící stroj, aby zase žehlil kravaty. Zangemann totiž kravaty nesnášel, a tak to strojům zakázal. Pro paní řidičku autobusu postavili zavlažovač z hadic a starého počítače – aby jí rostliny v létě nevyschly. A školníkovi upravili vysavač tak, aby poznal pohozené hračky a nevsál je.
+Někdy dokázali pomoct i dospělým. Tonda přeprogramoval tatínkův žehlící stroj, aby zase žehlil kravaty. Kleštil totiž kravaty nesnášel, a tak to strojům zakázal. Pro paní řidičku autobusu postavili zavlažovač z hadic a starého počítače – aby jí rostliny v létě nevyschly. A školníkovi upravili vysavač tak, aby poznal pohozené hračky a nevsál je.
 
-A někdy tvořili prostě jen pro zábavu. Například vymysleli prdící modul do židle paní Gernetové, učitelky matematiky. Kdykoli si sedla, ozval se malý prd. Paní učitelka sice vždycky nadávala, ale Ada byla přesvědčená, že se nad tím potají usmívá.
+A někdy tvořili prostě jen pro zábavu. Například vymysleli prdící modul do židle paní Zlomkové, učitelky matematiky. Kdykoli si sedla, ozval se malý prd. Paní učitelka sice vždycky nadávala, ale Ada byla přesvědčená, že se nad tím potají usmívá.
 
 ## 36 ##
 
 ==== Slide 19
-Jednoho dne si Zangemann všiml, že některé počítače už neposlouchají jeho příkazy. Vyděsil se – a vztekem téměř explodoval. Okamžitě zavolal prezidentovi a přeskakujícím hlasem do telefonu křičel: „Někdo přepisuje programy v mých zařízeních! To je nepřijatelné – to jsou přece moje vynálezy! A je nebezpečné, když si každý může s počítačem dělat, co se mu zlíbí. Musí se to zakázat zákonem!“
+Jednoho dne si Kleštil všiml, že některé počítače už neposlouchají jeho příkazy. Vyděsil se – a vztekem téměř explodoval. Okamžitě zavolal prezidentovi a přeskakujícím hlasem do telefonu křičel: „Někdo přepisuje programy v mých zařízeních! To je nepřijatelné – to jsou přece moje vynálezy! A je nebezpečné, když si každý může s počítačem dělat, co se mu zlíbí. Musí se to zakázat zákonem!“
 
-Prezident nechtěl Zangemanna rozhněvat – vždyť všechny vládní počítače naprogramoval právě on. Bez nich by stát vůbec nefungoval. A tak parlament přijal nový zákon, přesně podle Zangemanna: „Všechny počítače, které neposlouchají Zangemanna, jsou zakázány! Kdo jeho zařízení přeprogramuje, musí zaplatit pokutu 500 000 zlatých!“
+Prezident nechtěl Kleštila rozhněvat – vždyť všechny vládní počítače naprogramoval právě on. Bez nich by stát vůbec nefungoval. A tak parlament přijal nový zákon, přesně podle Kleštila: „Všechny počítače, které neposlouchají Kleštila, jsou zakázány! Kdo jeho zařízení přeprogramuje, musí zaplatit pokutu 500 000 zlatých!“
 
 ## 37 ##
 
 [[I:ada-p37
-OBRÁZEK: Prezident přijímá telefonát od rozzuřeného Zangemanna.
-Videotelefon se skládá ze starého červeného Zangemannova telefonního přístroje s otočným číselníkem, připojeného k monitoru. Na monitoru se objevuje Zangemannův obličej, zatímco z telefonu vychází žluté blesky Zangemannova hromového hlasu. Prezident drží sluchátko na délku paže.
+OBRÁZEK: Prezident přijímá telefonát od rozzuřeného Kleštila.
+Videotelefon se skládá ze starého červeného Kleštilova telefonního přístroje s otočným číselníkem, připojeného k monitoru. Na monitoru se objevuje Kleštilův obličej, zatímco z telefonu vychází žluté blesky Kleštilova hromového hlasu. Prezident drží sluchátko na délku paže.
 
 Prezident má bílé vlasy, nosí světle modrou košili, červenou kravatu a modré sako se žlutými knoflíky. Sedí na zelené židli s bílými svislými pruhy, a jeho druhá ruka spočívá na stole. Tam, kromě videotelefonu, leží listy s textem a otevřené fialové plnicí pero.
 
@@ -530,7 +529,7 @@ Prezident má před sebou načatý sendvič s masem, sýrem, zeleninou a dvěma 
 ## 38
 
 ==== Slide 20
-Když se Ada a její přátelé dozvěděli, co Zangemann provedl, pořádně se rozzlobili. „To je tak nespravedlivé! Naše skateboardy jsme si přece sami postavili i naprogramovali. Teď jsou mnohem lepší – a nenecháme si je vzít!“ 
+Když se Ada a její přátelé dozvěděli, co Kleštil provedl, pořádně se rozzlobili. „To je tak nespravedlivé! Naše skateboardy jsme si přece sami postavili i naprogramovali. Teď jsou mnohem lepší – a nenecháme si je vzít!“ 
 
 Všichni se sešli u jednoho z vlastnoručně přestavěných zmrzlinových strojů a přemýšleli, co s tím. Bylo jasné, že proti novému zákonu musí něco podniknout. A tak vymysleli plán...
 
@@ -545,7 +544,7 @@ světle zelený označovač a svinutý transparent, na kterém ulpělo něco mod
 
 Druhý den do školy nešli. Místo toho se Ada a její kamarádi vydali na skateboardech k parlamentu – s velkými barevnými transparenty v rukou. Některé z nich večer ozdobili LED světýlky, která teď jasně blikala. Reproduktory propojili, aby bylo jejich poselství slyšet v každé ulici. Zvědaví kolemjdoucí se zastavovali a ptali se: „Proč protestujete?“ „Za svobodu softwaru!“ odpověděly děti sborově – a vyprávěly svůj příběh. Dospělí uznale přikyvovali – a i prezident si zvědavě prohlédl plakáty, když vstupoval do budovy.
 
-A ani další dny nepřestali. Ada a její přátelé se znovu usadili před parlamentem. Tentokrát už nebyli sami – přidali se spolužáci, kterým Ada upravila skateboardy. Dorazil i Toniho otec a další dospělí. Všichni chápali, že vynálezy těchto dětí jsou k užitku.
+A ani další dny nepřestali. Ada a její přátelé se znovu usadili před parlamentem. Tentokrát už nebyli sami – přidali se spolužáci, kterým Ada upravila skateboardy. Dorazil i Tondův otec a další dospělí. Všichni chápali, že vynálezy těchto dětí jsou k užitku.
 
 [[I:ada-p39
 OBRÁZEK: Kapky žluté a zelené barvy na zemi a žluté, červené, modré, zelené a hnědé voskovky. Poslední tři v šedé lepenkové krabičce.
@@ -553,19 +552,19 @@ OBRÁZEK: Kapky žluté a zelené barvy na zemi a žluté, červené, modré, ze
 
 ## 40 ##
 
-Každým dnem přibývalo víc a víc protestujících. Přijela i řidička autobusu, které děti pomohly s rostlinami – a hlasitě troubila, aby si všimli i ostatní. Školník přivedl několik svých přátel. A Toniho otec dorazil se svými kolegy – všichni měli perfektně vyžehlené kravaty. Dokonce i paní Gernetová, učitelka matematiky, se objevila mezi protestujícími. Dav rostl každým dnem a po pár týdnech už se neprotestovalo jen v Adině městě. Demonstrace vypukly po celé zemi.
+Každým dnem přibývalo víc a víc protestujících. Přijela i řidička autobusu, které děti pomohly s rostlinami – a hlasitě troubila, aby si všimli i ostatní. Školník přivedl několik svých přátel. I Tondův otec dorazil se svými kolegy – všichni měli perfektně vyžehlené kravaty. Dokonce i paní Zlomková, učitelka matematiky, se objevila mezi protestujícími. Dav rostl každým dnem a po pár týdnech už se neprotestovalo jen v Adině městě. Demonstrace vypukly po celé zemi.
 
 [[I:ada-p40-41
 OBRÁZEK: Skupina protestujících. Mezi nimi jsou:
 Adina matka držící Alana za ruku a zvedající růžovou zmrzlinu;
-tři kolegové Toniho otce oblečení v kravatách;
+tři kolegové Tondova otce oblečení v kravatách;
 dvě děti držící transparent „Udělete si domácí úkol, pane prezidente, a my uděláme ten náš!“;
 robot s pásovým podvozkem, žehličkami místo nohou, elektrickým větrákem jako břichem, monitorem jako hlavou a metlou jako jednou rukou, který v druhé ruce drží modrou zmrzlinu;
 dva rodiče držící transparent „Programováním za svobodu“;
 dáma držící elektronický nápis „Je tu kód B“;
 dva malí ptáci létající nad hlavami;
-učitelka matematiky, paní Gernetová, která vložila do svého vozíku ceduli s nápisem „Jsou mladí a potřebují kód!“ Její pes ve vozíku štěká;
-Ada a Konrad nesou transparent „Neničte naši techniku!“ Marie a Toni jdou pod transparentem a Marie mluví do megafonu, který drží v ruce;
+učitelka matematiky, paní Zlomková, která vložila do svého vozíku ceduli s nápisem „Jsou mladí a potřebují kód!“ Její pes ve vozíku štěká;
+Ada a Karlík nesou transparent „Neničte naši techniku!“ Marie a Tonda jdou pod transparentem a Marie mluví do megafonu, který drží v ruce;
 Adin pes má nyní červený postroj se zářivými žlutými LED diodami, který ladí s jeho obojkem.
 ]]
 
@@ -577,7 +576,7 @@ VELKÝ NÁPIS: "Udělejte si domácí úkol, pane prezidente, a my uděláme ten
 OBRÁZEK: Detail předchozího obrázku: dvě děti nesou transparent "Udělejte si domácí úkol, pane prezidente, a my uděláme ten svůj!"
 ]]
 [[I:ada-p41
-Ada a Konrad nesou transparent “Neničte naši techniku!” Marie a Toni jdou pod transparentem a Marie mluví do megafonu, který drží v ruce. Adin pes má nyní červený postroj se zářivými žlutými LED diodami, který ladí s jeho obojkem.
+Ada a Karlík nesou transparent “Neničte naši techniku!” Marie a Tonda jdou pod transparentem a Marie mluví do megafonu, který drží v ruce. Adin pes má nyní červený postroj se zářivými žlutými LED diodami, který ladí s jeho obojkem.
 ]]
 
 TRANSPARENT UČITELKY: "Jsou mladí a potřebují kód!"
@@ -590,7 +589,7 @@ Ada protestovala před parlamentem každý týden. I v lijáku. Ať pršelo nebo
 
 Ada se postavila a klidně odpověděla: „Chceme sami rozhodovat, co smíme a nesmíme dělat se svými počítači.“ A její přátelé a kamarádky vykřikli sborově: „Bez kódu se nedá žít! Bez kódu se nedá žít!“
 
-Prezident se zahleděl do odhodlaných dětských tváří. A měl-li být upřímný – i on by si přál, aby vláda rozhodovala o svém softwaru sama. Jenže programování nerozuměl, a tak vše nechával na Zangemannovi. Zamyšleně vešel do parlamentu.
+Prezident se zahleděl do odhodlaných dětských tváří. A měl-li být upřímný – i on by si přál, aby vláda rozhodovala o svém softwaru sama. Jenže programování nerozuměl, a tak vše nechával na Kleštilovi. Zamyšleně vešel do parlamentu.
 
 ==== Slide 22
 
@@ -598,40 +597,40 @@ Prezident se zahleděl do odhodlaných dětských tváří. A měl-li být upř�
 OBRÁZEK: Jeden z Adiných přátel leží na břiše, s jednou nohou ve vzduchu, a píše na notebooku. Má vlnité hnědé vlasy rozdělené uprostřed, červenou mikinu, modré kalhoty a bílé ponožky, ale žádné boty. Vedle počítače je zelený hrnek a dvě otevřené knihy.
 ]]
 
-Další den pozval prezident Adu a její přátele do své kanceláře. „I my chceme rozhodovat o svém vlastním softwaru,“ řekl. „Ale k tomu musí být vláda nezávislá na Zangemannovi. Můžete mi vysvětlit, co víte o počítačových programech?“ Děti mu nadšeně vyprávěly, jak software funguje a co všechno s ním dokážou. Prezident jen užasle naslouchal.
+Další den pozval prezident Adu a její přátele do své kanceláře. „I my chceme rozhodovat o svém vlastním softwaru,“ řekl. „Ale k tomu musí být vláda nezávislá na Kleštilovi. Můžete mi vysvětlit, co víte o počítačových programech?“ Děti mu nadšeně vyprávěly, jak software funguje a co všechno s ním dokážou. Prezident jen užasle naslouchal.
 
 ## 43 ##
 
-Díky těmto novým znalostem mohla vláda začít vyvíjet svůj vlastní software – bez Zangemanna. Prezident ihned svolal poradce a společně s dětmi diskutovali o tom, co všechno by šlo změnit a zlepšit.  Toho večera se děti vracely domů pyšné a spokojené. Konečně se něco dělo. Jejich protest měl smysl!
+Díky těmto novým znalostem mohla vláda začít vyvíjet svůj vlastní software – bez Kleštila. Prezident ihned svolal poradce a společně s dětmi diskutovali o tom, co všechno by šlo změnit a zlepšit.  Toho večera se děti vracely domů pyšné a spokojené. Konečně se něco dělo. Jejich protest měl smysl!
 
 [[I:ada-p43
 OBRÁZEK: Ada a její přátelé v kanceláři prezidenta. Ada přeprogramovává prezidentův počítač.
-Toni nastavuje reproduktor pro prezidentovu sekretářku. Marie a Konrad sedí na podlaze a povídají si, Marie má na klíně notebook s nálepkou loga FSFE (tři hvězdy: hráškově zelená, nebesky modrá a mořsky modrá).
+Tonda nastavuje reproduktor pro prezidentovu sekretářku. Marie a Karlík sedí na podlaze a povídají si, Marie má na klíně notebook s nálepkou loga FSFE (tři hvězdy: hráškově zelená, nebesky modrá a mořsky modrá).
 Na podlaze je miska s bonbóny a talíř se zmrzlinou. Prezidentův telefon zvoní, ale nikdo ho nezvedá.
 ]]
 
 ## 44 ##
 
-Následující ráno zazvonil vládní telefon. Volal Zangemann – naštvanější než kdy jindy. „Beze mě vám ty počítače nepojedou!“ hřímal. Ale prezident se jen usmál, vzal sluchátko a zavěsil. Ten den telefon zvonil ještě mnohokrát, ale nikdo ho nezvedl. Prezident měl totiž schůzku s Adou, Tonim, Marií, Konradem a týmem vládních expertů.
+Následující ráno zazvonil vládní telefon. Volal Kleštil – naštvanější než kdy jindy. „Beze mě vám ty počítače nepojedou!“ hřímal. Ale prezident se jen usmál, vzal sluchátko a zavěsil. Ten den telefon zvonil ještě mnohokrát, ale nikdo ho nezvedl. Prezident měl totiž schůzku s Adou, Tondou, Marií, Karlíkem a týmem vládních expertů.
 
 [[I:ada-p44
 OBRÁZEK: Herold, který má na sobě klobouk s perem, troubí na trubku, na které visí červený prapor.
 ]]
 
 
-V dalších dnech společně pracovali od rána do večera a navrhovali první programy pro vládní systémy. Zangemannovy telefonáty je už nerušily. Toni přišel s nápadem přeprogramovat linku – a tak když Zangemann zavolal, ozvalo se jen: „Vláda chce používat jen software, který může volně používat, chápat, šířit a vylepšovat. Děkujeme za zavolání.“
+V dalších dnech společně pracovali od rána do večera a navrhovali první programy pro vládní systémy. Kleštilovy telefonáty je už nerušily. Tonda přišel s nápadem přeprogramovat linku – a tak když Kleštil zavolal, ozvalo se jen: „Vláda chce používat jen software, který může volně používat, chápat, šířit a vylepšovat. Děkujeme za zavolání.“
 
 ==== Slide 23
-Po mnoha týdnech k tomu konečně došlo. Parlament zrušil starý Zangemannův zákon! Místo toho bylo vyhlášeno:
+Po mnoha týdnech k tomu konečně došlo. Parlament zrušil starý Kleštilův zákon! Místo toho bylo vyhlášeno:
 
 ## 45 ##
 
 „Všichni lidé mohou sami programovat své počítače, pokud se přitom budou řídit ostatními zákony.“ A kromě toho byl zaveden nový školní předmět: Počítače a programování.
 
 [[I:ada-p45
-OBRÁZEK: Prezident s Tonim, Konradem, Marií, Adou a heroldem hrajícím na trubku.
+OBRÁZEK: Prezident s Tondou, Karlíkem, Marií, Adou a heroldem hrajícím na trubku.
 Marie stojí na vrcholu žebříku a mluví do mikrofonu.
-Konrad pevně drží žebřík, na kterém Marie stojí.
+Karlík pevně drží žebřík, na kterém Marie stojí.
 Ada stojí na židli a drží kopii nového zákona s pečetí.
 Adin pes sedí před ní.
 ]]
@@ -639,7 +638,7 @@ Adin pes sedí před ní.
 ## 46 ##
 
 ==== Slide 24
-Ten večer se konala velká slavnost. Sešli se Ada, Alan, děti ze školy i jejich rodiče, prezident, paní Gernetová, řidička autobusu i školník. Ulice byly vyzdobené, hrála hlasitá hudba – a všichni si pochutnávali na zmrzlině ve všech možných barvách a tvarech.
+Ten večer se konala velká slavnost. Sešli se Ada, Alan, děti ze školy i jejich rodiče, prezident, paní Zlomková, řidička autobusu i školník. Ulice byly vyzdobené, hrála hlasitá hudba – a všichni si pochutnávali na zmrzlině ve všech možných barvách a tvarech.
 
 [[I:ada-p46
 OBRÁZEK: Večerní párty.
@@ -647,26 +646,26 @@ Děti drží zmrzlinu a balónky s nápisem „I love FS (I love Free Software)�
 další děti jezdí na skateboardech;
 mezi lampami jsou natažené provazy se žlutými a oranžovými vlaječkami;
 z velkého reproduktorového systému hraje hudba;
-paní Gernetová drží růžovou zmrzlinu ve tvaru stromu se žlutou hvězdou na vrcholu;
+paní Zlomková drží růžovou zmrzlinu ve tvaru stromu se žlutou hvězdou na vrcholu;
 Adina máma tančí s nějakým pánem.
 ]]
 
 ## 47 ##
 
-Zatímco ostatní slavili až do noci, Ada, Toni, Marie a Konrad se tiše vytratili a zamířili do své dílny. Měli hlavu plnou nových nápadů – a nemohli se dočkat, až se do nich pustí.
+Zatímco ostatní slavili až do noci, Ada, Tonda, Marie a Karlík se tiše vytratili a zamířili do své dílny. Měli hlavu plnou nových nápadů – a nemohli se dočkat, až se do nich pustí.
 
 [[I:ada-p47
 OBRÁZEK: Prezident, sekretářka a další lidé kolem stolu si užívají bláznivou zmrzlinu,
 žluté a oranžové vlajky pokračují z předchozího obrázku,
 malá dívka, která si právě vzala růžovou zmrzlinu ve tvaru ducha z upraveného zmrzlinového stroje,
-Adin pes, Konrad, Marie, Ada a Toni se potichu vytrácejí z oslavy.
+Adin pes, Karlík, Marie, Ada a Tonda se potichu vytrácejí z oslavy.
 ]]
 
 ## 48 ##
 
 ==== Slide 25
 
-A Zangemann? Od té doby o něm nikdo neslyšel. Možná dodnes zuří ve své obrovské vile a mračí se před svým zlatým počítačem. Možná se už ani neodvažuje vyjít na ulici – a dokonce zalepil všechna okna svého domu, aby nemusel vidět, co všechno lidé s jeho vynálezy dělají. Ale možná… možná se občas podívá dalekohledem ven do světa. A když vidí, co děti každý den nového vymýšlejí, možná si vzpomene, jak i jeho samotného kdysi bavilo vynalézat a zkoušet nové věci. A možná, úplně možná, přitom líže malinovou zmrzlinu ve tvaru pyramidy s duhovým posypem.
+A Kleštil? Od té doby o něm nikdo neslyšel. Možná dodnes zuří ve své obrovské vile a mračí se před svým zlatým počítačem. Možná se už ani neodvažuje vyjít na ulici – a dokonce zalepil všechna okna svého domu, aby nemusel vidět, co všechno lidé s jeho vynálezy dělají. Ale možná… možná se občas podívá dalekohledem ven do světa. A když vidí, co děti každý den nového vymýšlejí, možná si vzpomene, jak i jeho samotného kdysi bavilo vynalézat a zkoušet nové věci. A možná, úplně možná, přitom líže malinovou zmrzlinu ve tvaru pyramidy s duhovým posypem.
 
 [[I:ada-p48
 OBRÁZEK: Adin pes čichá ke stopě ze zmrzliny.
@@ -693,7 +692,7 @@ Upřímné díky patří mé rodině, která mě nechávala psát brzy ráno, po
 ## 51 ##
 
 [[I:ada-p51
-OBRÁZEK: Adin pes vrtí ocasem, když objevil Zangemanna schovaného za
+OBRÁZEK: Adin pes vrtí ocasem, když objevil Kleštila schovaného za
 závěsem, jak jí zmrzlinový kornout s bonbóny, má v něm zapíchnutý modrý
 deštníček a z něj ukapává spousta malinové zmrzliny.
 ]]
@@ -734,7 +733,7 @@ Na webové stránce ke knize najdete další informace a materiály: https://ada
 
 Licence
 
-Kniha „Ada & Zangemann – Pohádka o softwaru, skateboardech a malinové zmrzlině“ od Matthiase Kirschnera a Sandry Brandstätterové, vydaná nakladatelstvím dpunkt.verlag GmbH, je chráněna pod licencí „Creative Commons Attribution–ShareAlike 4.0 International (CC BY-SA 4.0)“.
+Kniha „Ada & Kleštil – Pohádka o softwaru, skateboardech a malinové zmrzlině“ od Matthiase Kirschnera a Sandry Brandstätterové, vydaná nakladatelstvím dpunkt.verlag GmbH, je chráněna pod licencí „Creative Commons Attribution–ShareAlike 4.0 International (CC BY-SA 4.0)“.
 
 https://creativecommons.org/licenses/by-sa/4.0
 
@@ -765,7 +764,7 @@ OBRÁZEK: Páječka, štětec a plechovka se žlutou barvou propojené bílou
 elektrickou šňůrou, která tvoří rámeček kolem obrázku.
 ]]
 
-Vynálezce Zangemann je světově proslulý a nesmírně bohatý. Dospělí i děti milují jeho úžasné technické vynálezy. Jednoho dne se však objeví problém: Elektronické skateboardy dětí přestaly správně fungovat. Co se to děje? Zvídavá Ada tu záhadu odhalí. Společně se svými přáteli začne experimentovat s vlastními počítačovými programy a děti zosnují plán: Zangemann už nesmí mít jako jediný kontrolu nad počítači!
+Vynálezce Kleštil je světově proslulý a nesmírně bohatý. Dospělí i děti milují jeho úžasné technické vynálezy. Jednoho dne se však objeví problém: Elektronické skateboardy dětí přestaly správně fungovat. Co se to děje? Zvídavá Ada tu záhadu odhalí. Společně se svými přáteli začne experimentovat s vlastními počítačovými programy a děti zosnují plán: Kleštil už nesmí mít jako jediný kontrolu nad počítači!
 
 Kniha pro děti, která přináší radost z vynalézání a povzbuzuje k samostatnému zacházení s technologiemi.
 


### PR DESCRIPTION
Tento PR je finální překlad knihy do češtiny, který jsem mnohokrát prošel a snažil se jej jazykově co nejvíce vycizelovat. Jsou zde dva soubory

* Ada_Zangemann-cs.txt
* Ada_Zangemann-cs_jmena.txt

Ten první je překlad, jak to je, aniž bych zasáhl do jmen. Tedy zůstávají tam originální německá jména. Ale! "Zangemann" má v němčině význam, symboliku. Znamená to "klešťový muž", tedy někdo, kdo rád dělá s elektrikou, ale zároveň drží svět v proprietárních "kleštích". Možná by tedy stálo za to tento význam do češtiny přenést, použil jsem tedy zkusmo jméno "Kleštil". Nic lepšího mě s kleštěma nenapadlo. Také jsem počeštil další jména. "Toni" v češtině vypadá jako kolotočářský synek, tak to bude "Tonda". "Konrad" mi evokuje 30. léta minulého století, tak dávám jako volbu "Karlík". Učitelka matematiky "paní Zlomková" už jenom mírně dokresluje. Tento překlad je v souboru *jmena.txt.
Já si myslím, že by bylo škoda tu symboliku jména do knihy nedat. 

Přineslo by to ale nutnost předělat logo Z na ilustracích na logo K. To ale asi problém nebude, stejně se budou muset předělat titulky, názvy, atd. 

Přečti si to, Miro,  a můžem to ještě probrat. 